### PR TITLE
Fix/update for latest gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,7 @@
 PATH
   remote: .
   specs:
-    scad_bundler (0.1.2)
-      bundler (~> 1.16)
+    scad_bundler (0.1.3)
 
 GEM
   remote: https://rubygems.org/
@@ -12,8 +11,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 2.0)
   scad_bundler!
 
 BUNDLED WITH
-   1.16.1
+   2.5.7

--- a/bin/scad_bundle
+++ b/bin/scad_bundle
@@ -15,7 +15,7 @@ require 'shellwords'
 # different implementations later.
 command = ARGV.shift
 
-if command != 'init' && ! File.exists?('Scadfile')
+if command != 'init' && ! File.exist?('Scadfile')
   puts 'Could not find Scadfile'
   exit(1)
 end
@@ -23,7 +23,7 @@ end
 case command
 when 'init'
   # Setup new Scadfile
-  if File.exists?('Scadfile')
+  if File.exist?('Scadfile')
     puts 'Scadfile already exists!'
     exit(1)
   end

--- a/lib/scad_bundler/version.rb
+++ b/lib/scad_bundler/version.rb
@@ -1,3 +1,3 @@
 module ScadBundler
-  VERSION = "0.1.1"
+  VERSION = "0.1.3"
 end

--- a/scad_bundler.gemspec
+++ b/scad_bundler.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.executables   = ['scad_bundle']
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.0"
 end


### PR DESCRIPTION
- updated the name of depreciated function (exists? -> exist?)
- bumped bundler version

Tested by

1. Create new directory
2. `scad_bundle init`
3. Uncomment `gem 'openscad_soften'` in Scadfile
4. `scad_bundle install`
5. `scad_bundle exec env | grep OPENSCADPATH`
6. Observe correct env var value

